### PR TITLE
Support audit-argument-checks package

### DIFF
--- a/lib/easy-search-common.js
+++ b/lib/easy-search-common.js
@@ -57,6 +57,9 @@ EasySearch = (function () {
     name = opts.collection._name;
 
     Meteor.publish(name + '/easySearch', function (conf) {
+
+      check(conf, Object);
+
       var resultArray = [], resultSet;
 
       if (conf.limit) {


### PR DESCRIPTION
When using the audit-argument-checks package errors are throw because the publish function isn't checking its parameters. Here's a fix.
