### PR TITLE
Added resetAutosuggest() to the Component API

### DIFF
--- a/lib/components/easy-search-components.html
+++ b/lib/components/easy-search-components.html
@@ -1,6 +1,6 @@
 <!-- Input field for a search -->
 <template name="esInput">
-    <input type="text" id="{{id}}" placeholder="{{placeholder}}" class="{{class}} es-input" />
+    <input type="text" id="{{id}}" placeholder="{{placeholder}}" class="{{class}}" />
 </template>
 
 <!-- Loop through the search results -->

--- a/lib/components/easy-search-components.html
+++ b/lib/components/easy-search-components.html
@@ -1,6 +1,6 @@
 <!-- Input field for a search -->
 <template name="esInput">
-    <input type="text" id="{{id}}" placeholder="{{placeholder}}" class="{{class}}" />
+    <input type="text" id="{{id}}" placeholder="{{placeholder}}" class="{{class}} es-input" />
 </template>
 
 <!-- Loop through the search results -->
@@ -69,7 +69,7 @@
 
 <!-- Fully self working autosuggest -->
 <template name="esAutosuggest">
-    <div class="es-autosuggest-wrapper" data-id="{{id}}" data-index="{{index}}"> 
+    <div class="es-autosuggest-wrapper" data-id="{{id}}" data-index="{{index}}">
         <div class="selected values">
             {{#each selectedValue}}
                 <span class="value">

--- a/lib/components/easy-search-components.js
+++ b/lib/components/easy-search-components.js
@@ -633,6 +633,42 @@ EasySearch.getComponentInstance = (function () {
         return autorun(function () {
           eventFunction(SearchVars.get(componentScope.generateId(), key));
         });
+      },
+      resetAutosuggest : function (context) {
+        var esInput;
+
+        // Try to find the esInput using a jQuery context if we have one
+        if (context) {
+          esInput = $(context).find('input.es-input');
+        }
+
+        // If we can't find it using a context, figure out what we do have and build a selector
+        if (!esInput) {
+          var parentSelector = '.es-autosuggest-wrapper';
+          var esInputSelector = ' input.es-input';
+
+          if (conf.id) {
+            parentSelector += '[data-id="' + conf.id + '"]';
+            esInputSelector += '#' + conf.id;
+          }
+
+          if (conf.index) {
+            parentSelector += '[data-index="' + conf.index + '"]';
+          }
+
+          esInput = $(parentSelector + esInputSelector);
+        }
+
+        // Better to be certain that we found exactly one esInput before we clear it
+        if (esInput && esInput.length === 1) {
+          esInput.val('');
+        }
+
+        // Clear the search results
+        this.clear();
+
+        // Clear the selected items
+        SearchVars.set(this.generateId(), { 'autosuggestSelected' : [] });
       }
     };
   };

--- a/lib/components/easy-search-components.js
+++ b/lib/components/easy-search-components.js
@@ -634,33 +634,10 @@ EasySearch.getComponentInstance = (function () {
           eventFunction(SearchVars.get(componentScope.generateId(), key));
         });
       },
-      resetAutosuggest : function (context) {
-        var esInput;
+      resetAutosuggest : function (esInput) {
 
-        // Try to find the esInput using a jQuery context if we have one
-        if (context) {
-          esInput = $(context).find('input.es-input');
-        }
-
-        // If we can't find it using a context, figure out what we do have and build a selector
-        if (!esInput) {
-          var parentSelector = '.es-autosuggest-wrapper';
-          var esInputSelector = ' input.es-input';
-
-          if (conf.id) {
-            parentSelector += '[data-id="' + conf.id + '"]';
-            esInputSelector += '#' + conf.id;
-          }
-
-          if (conf.index) {
-            parentSelector += '[data-index="' + conf.index + '"]';
-          }
-
-          esInput = $(parentSelector + esInputSelector);
-        }
-
-        // Better to be certain that we found exactly one esInput before we clear it
-        if (esInput && esInput.length === 1) {
+        // Clear the esInput field if one was supplied
+        if (esInput instanceof jQuery) {
           esInput.val('');
         }
 


### PR DESCRIPTION
Thank you for your Easy Search package, it is proving very useful. However, there wasn't a way to reset the selected items in the autosuggest component, so I added one. I hope you don't mind. It does three things:

* Clears the esInput field if it can find it
* Clears the search results via calling the already-built-in .clear()
* Clears the selected items

.resetAutosuggest() accepts an optional context parameter to help it find the correct esInput field in case there's more than one autosuggest component on the page. If a context isn't provided, .resetAutosuggest() builds a selector using the component's id and index properties if they're set. To guard against edge cases, it will only clear the esInput field if jQuery finds exactly one.

Example usage:

```
<template name="myForm">
  <div class="my-form">
    {{> esAutosuggest index="tags" id="myFormTags" placeholder="Add tags"}}
    <button class="cancel">Cancel</button>
  </div>
</template>

Template.myForm.events({
  'click .cancel' : function (e) {
    var instance = EasySearch.getComponentInstance({
      'id': 'myFormTags',
      'index': 'tags'
    });
    
    var context = $(e.target).parent();
    
    instance.resetAutosuggest(context);
  }
});
```