### PR TITLE
build pre/found/post strings for every suggestion field

### DIFF
--- a/lib/components/easy-search-components.js
+++ b/lib/components/easy-search-components.js
@@ -526,36 +526,55 @@ EasySearch.getComponentInstance = (function () {
       return (inputValue && inputValue.length > 0) && searchingDone  ? 'show' : 'hide';
     },
     'snippets' : function (options) {
-      var regex, firstFieldValue, searchValue, parts,
+      var firstFieldValue, parts, fieldValue, firstField,
         index = EasySearch.getIndex(options.index),
-        firstField  = _.isArray(index.field) ? index.field[0] : index.field;
+        self = this,
+        searchValue = autosuggestCache.value,
+        regex = new RegExp(searchValue + '(.+)?', 'i'),
+        results = {},
+        fieldResult = {};
 
-      firstFieldValue = this[firstField];
-
-      if (!_.isString(firstFieldValue)) {
-        throw new Error(m.firstValueStringAutosuggest);
+      if (!_.isArray(index.field)) {
+        index.field = [index.field];
       }
+      firstField = index.field[0];
 
-      searchValue = autosuggestCache.value;
-      regex = new RegExp(searchValue + '(.+)?', "i");
-      parts = firstFieldValue.split(regex);
+      _.each(index.field, function (field) {
 
-      // Not found in the first field
-      if (parts.length === 1) {
-        return {
-          'pre' : firstFieldValue,
-          'value' : firstFieldValue,
-          'id' : this._id,
-          'options' : options
-        };
-      }
+        fieldValue = self[field];
+
+        if (!_.isString(fieldValue)) {
+          fieldValue = '';
+        }
+
+        parts = fieldValue.split(regex);
+
+        if (parts.length > 1) {
+          fieldResult = {
+            'pre': parts[0],
+            'post' : parts[1],
+            'value': fieldValue,
+            'found': (new RegExp(searchValue, 'i')).exec(fieldValue).shift()
+          };
+        } else {
+          fieldResult = {
+            'pre': '',
+            'post' : fieldValue,
+            'value': fieldValue,
+            'found': ''
+          };
+        }
+        results[field] = fieldResult;
+
+      });
 
       return {
-        'pre' : parts[0],
-        'found' : (new RegExp(searchValue, 'i')).exec(firstFieldValue).shift(),
-        'post' : parts[1],
-        'value' : firstFieldValue,
+        'pre' : results[firstField].pre,
+        'found' : results[firstField].found,
+        'post' : results[firstField].post,
+        'value' : results[firstField].value,
         'id' : this._id,
+        'esResults': results,
         'doc' : this,
         'options' : options
       };


### PR DESCRIPTION
This patch allows you to use pre / found / post variables for every searchable field.
It alway returns the doc object no matter what field you're looking for.
```html
<template name="suggestionTpl">
  {{esResults.firstname.pre}}<span class="found">{{esResults.firstname.found}}</span>{{esResults.firstname.post}}
  {{esResults.lastname.pre}}<span class="found">{{esResults.lastname.found}}</span>{{esResults.lastname.post}}
</template>
```
It also keeps backward compatibility by returning the pre / found / post variables from the first field like it did before.