### PR TITLE
Add a possibility to set the default value of the search input

### DIFF
--- a/lib/components/easy-search-components.html
+++ b/lib/components/easy-search-components.html
@@ -1,6 +1,6 @@
 <!-- Input field for a search -->
 <template name="esInput">
-    <input type="{{type}}" id="{{id}}" placeholder="{{placeholder}}" class="{{class}}" />
+    <input type="{{type}}" id="{{id}}" placeholder="{{placeholder}}" class="{{class}}" value="{{value}}"/>
 </template>
 
 <!-- Loop through the search results -->

--- a/lib/components/easy-search-components.js
+++ b/lib/components/easy-search-components.js
@@ -248,6 +248,7 @@ EasySearch.getComponentInstance = (function () {
         opts.countSubscriptionHandle = Meteor.subscribe(index + '/easySearchCount');
       });
     });
+	this.$('input').keyup(); // In case we have something in the field, search - That is also the case if we have a code refresh!
   };
 
   Template.esInput.destroyed = function () {
@@ -278,7 +279,6 @@ EasySearch.getComponentInstance = (function () {
         allDocsOnEmpty = this.allDocsOnEmpty,
         searchValue = input.val().trim(),
         keyCode = e.keyCode || e.which;
-
       // Reset values if search value is empty
       if (searchValue.length === 0 && !allDocsOnEmpty) {
         EasySearch.eachIndex(this.index, function (index) {
@@ -287,7 +287,6 @@ EasySearch.getComponentInstance = (function () {
 
         return;
       }
-
       // Do not search when the value hasn't changed or pressed other key than enter with enter configuration
       if ((inputCache === searchValue) || ("enter" === event && 13 !== keyCode)) {
         EasySearch.eachIndex(this.index, function (index) {
@@ -298,7 +297,6 @@ EasySearch.getComponentInstance = (function () {
       }
 
       inputCache = searchValue;
-
       EasySearch.eachIndex(this.index, function (index) {
         id = generateId(index, eventScope.id);
 
@@ -306,7 +304,6 @@ EasySearch.getComponentInstance = (function () {
         if (LocalTimer.isRunning(id)) {
           LocalTimer.stop(id);
         }
-
         // Set to default limit and reset pagination
         EasySearch.changeLimit(index, SearchVars.get(id, 'defaultLimit'));
         paginate(index, eventScope.id, 1);


### PR DESCRIPTION
The first commit commits add the parameter `value` to the `esInput` template. This enables developers to pre-fill the search input. Also, in case of a hot code push, if the search input is not empty, previous versions would not automatically search for results, even if those were displayed before the refresh. The second commit fixes that

**Use case :**
In a files database, the file upload may first require the user to provide the file, then some analysis could enable the code to guess the tags the file might belong to. Thanks to this, the user has directly the search results and can directly select the tag if the guess is correct.