### PR TITLE
Add a way to restrict access to the search index

### DIFF
--- a/lib/easy-search-common.js
+++ b/lib/easy-search-common.js
@@ -14,7 +14,7 @@ EasySearch = (function () {
       'props' : {},
       'auth'  : function(a){
         return true;
-      }
+      },
       'transform' : function () {},
       'sort' : function () {
         if (Searchers[this.use]) {
@@ -66,11 +66,11 @@ EasySearch = (function () {
         publishScope = this,
         resultIds = [],
         publishHandle;
-
+	  
       check(conf, { value: Match.Optional(String), skip: Number, limit: Match.Optional(Number), props: Object });
       
-      if(!(indexes[name](this.userId))) // If the user is not allowed to perform this search, deny it.
-        return false;
+      if(!(indexes[name].auth(this.userId))) // If the user is not allowed to perform this search, deny it.
+        throw new Meteor.Error(403, "You're not allowed to search this index !");
       
       indexes[name].skip = conf.skip;
       indexes[name].limit = conf.limit || indexes[name].limit;

--- a/lib/easy-search-common.js
+++ b/lib/easy-search-common.js
@@ -66,7 +66,7 @@ EasySearch = (function () {
         publishScope = this,
         resultIds = [],
         publishHandle;
-	  
+
       check(conf, { value: Match.Optional(String), skip: Number, limit: Match.Optional(Number), props: Object });
       
       if(!(indexes[name].auth(this.userId))) // If the user is not allowed to perform this search, deny it.

--- a/lib/easy-search-common.js
+++ b/lib/easy-search-common.js
@@ -12,6 +12,9 @@ EasySearch = (function () {
       'reactive' : true,
       'useTextIndexes' : false,
       'props' : {},
+      'auth'  : function(a){
+        return true;
+      }
       'transform' : function () {},
       'sort' : function () {
         if (Searchers[this.use]) {
@@ -65,7 +68,10 @@ EasySearch = (function () {
         publishHandle;
 
       check(conf, { value: Match.Optional(String), skip: Number, limit: Match.Optional(Number), props: Object });
-
+      
+      if(!(indexes[name](this.userId))) // If the user is not allowed to perform this search, deny it.
+        return false;
+      
       indexes[name].skip = conf.skip;
       indexes[name].limit = conf.limit || indexes[name].limit;
       indexes[name].props = _.extend(indexes[name].props, conf.props);


### PR DESCRIPTION
This enables developpers to restrict access to a search index by providing the `auth` parameter. This parameter is a function that takes as argument a userId (or null if the user is not connected), and returns `true` is the user is allowed to access the search index, or `false` if not allowed.