### PR TITLE
Fix a typo in the docs

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -164,7 +164,7 @@ if (Meteor.isClient) {
       ...
 
       // Change the currently filteredCategories like this
-      EasySearch.changeProperty('products', 'filteredCategories', categories);
+      EasySearch.changeProperty('cars', 'filteredCategories', categories);
       // Trigger the search again, to reload the new products
       instance.triggerSearch();
     }


### PR DESCRIPTION
In the recipe for filtered search, the index used in the `changeProperty` is not the correct one : shouldn't you use "cars", not "products" ?