### PR TITLE
Only write elastic search index with fields that are specified in `options.field`

### DIFF
--- a/lib/searchers/elastic-search.js
+++ b/lib/searchers/elastic-search.js
@@ -3,20 +3,51 @@
 var Future = Npm.require('fibers/future'),
   ElasticSearch = Npm.require('elasticsearch');
 
+function deep(obj, key, value) {
+    var keys = key.replace(/\[(["']?)([^\1]+?)\1?\]/g, '.$2').replace(/^\./, '').split('.'),
+        root,
+        i = 0,
+        n = keys.length;
+
+    // Set deep value
+    if (arguments.length > 2) {
+
+      root = obj;
+      n--;
+
+      while (i < n) {
+        key = keys[i++];
+        obj = obj[key] = _.isObject(obj[key]) ? obj[key] : {};
+      }
+
+      obj[keys[i]] = value;
+
+      value = root;
+
+    // Get deep value
+    } else {
+      while ((obj = obj[keys[i++]]) != null && i < n) {};
+      value = i < n ? void 0 : obj;
+    }
+
+    return value;
+}
+
 /**
- * Return Elastic Search indexable data.
+ * Like _.pick(), but is compatible with object path.
  *
- * @param {Object} doc the document to get the values from
- * @return {Object}
+ * @param {Object} obj
+ * @returns {Object}
  */
-function getESFields(doc) {
-  var newDoc = {};
-
-  _.each(doc, function (value, key) {
-    newDoc[key] = _.isObject(value) && !_.isArray(value) && !_.isDate(value) ? JSON.stringify(value) : value;
-  });
-
-  return newDoc;
+function deepPick(obj) {
+    var ArrayProto = Array.prototype;
+    var copy = {};
+    var keys = ArrayProto.concat.apply(ArrayProto, ArrayProto.slice.call(arguments, 1));
+    _.each(keys, function(key) {
+        var val = deep(obj, key);
+        if (!_.isUndefined(val)) deep(copy, key, val);
+    });
+    return copy;
 }
 
 EasySearch.createSearcher('elastic-search', {
@@ -36,6 +67,8 @@ EasySearch.createSearcher('elastic-search', {
     if (_.isObject(transformedDoc)) {
       doc = transformedDoc;
     }
+
+    doc = deepPick(doc, opts.field);
 
     // add to index
     EasySearch.ElasticSearchClient.index({
@@ -73,11 +106,11 @@ EasySearch.createSearcher('elastic-search', {
 
     options.collection.find().observeChanges({
       added: function (id, fields) {
-        searcherScope.writeToIndex(name, getESFields(fields), id, options, config);
+        searcherScope.writeToIndex(name, fields, id, options, config);
       },
       changed: function (id) {
         // Overwrites the current document with the new doc
-        searcherScope.writeToIndex(name, getESFields(options.collection.findOne(id)), id, options, config);
+        searcherScope.writeToIndex(name, options.collection.findOne(id), id, options, config);
       },
       removed: function (id) {
         EasySearch.ElasticSearchClient.delete({

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'matteodem:easy-search',
   summary: "Easy-to-use search with Blaze Components (+ Elastic Search support)",
-  version: "1.6.2",
+  version: "1.6.3",
   git: "https://github.com/matteodem/meteor-easy-search.git"
 });
 


### PR DESCRIPTION
This PR enables the elastic-search searcher to honor the `field` option when calling `createSearchIndex(...)`. Currently, it serializes all fields and syncs it to elasticsearch, and I don't feel that that should be the default behavior. It should only sync the fields that the users are interested in.

By providing a `deepPick()` function, we can filter and pick even nested fields (it supports path-like field names).

For example, we can do something like:
```
EasySearch.createSearchIndex('users', {
  use: 'elastic-search'
  collection: Meteor.users
  field: ['username', 'profile.firstName', 'profile.lastName']
})
```