### PR TITLE
Support for Blaze Components 0.16.0

### DIFF
--- a/packages/easysearch:components/package.js
+++ b/packages/easysearch:components/package.js
@@ -10,8 +10,8 @@ Package.onUse(function(api) {
   api.versionsFrom('1.2.0.1');
 
   // Dependencies
-  api.use(['check', 'templating', 'reactive-dict', 'ecmascript', 'random', 'underscore', 'tracker']);
-  api.use(['peerlibrary:blaze-components@0.15.1', 'easysearch:core@2.0.5']);
+  api.use(['check', 'reactive-dict', 'ecmascript', 'random', 'underscore', 'tracker']);
+  api.use(['peerlibrary:blaze-components@0.16.0', 'easysearch:core@2.0.5']);
   api.use(['erasaur:meteor-lodash@3.10.0'], { weak: true });
 
   // Base Component


### PR DESCRIPTION
Upgrade to Blaze Components 0.16.0 is not needed, but if you do it, `templating` dependency in the package has to be removed.