### PR TITLE
pass sort and score fields via doc transform

### DIFF
--- a/packages/easysearch:elasticsearch/lib/engine.js
+++ b/packages/easysearch:elasticsearch/lib/engine.js
@@ -168,7 +168,7 @@ EasySearch.ElasticSearch = class ElasticSearchEngine extends EasySearch.Reactive
         return;
       }
 
-      let { total, ids } = this.getCursorData(data),
+      let { total, ids, hits } = this.getCursorData(data),
         cursor;
 
       if (ids.length > 0) {
@@ -176,7 +176,15 @@ EasySearch.ElasticSearch = class ElasticSearchEngine extends EasySearch.Reactive
           $or: _.map(ids, (_id) => {
             return { _id };
           })
-        }, { limit: options.search.limit });
+        }, {
+          limit: options.search.limit,
+          transform (doc) {
+            let hit = _.find(hits, { _id : doc._id });
+            doc._sort = hit.sort;
+            doc._score = hit._score;
+            return doc;
+          }
+        });
       } else {
         cursor = EasySearch.Cursor.emptyCursor;
       }
@@ -197,7 +205,8 @@ EasySearch.ElasticSearch = class ElasticSearchEngine extends EasySearch.Reactive
   getCursorData(data) {
     return {
       ids : _.map(data.hits.hits, (resultSet) => resultSet._id),
-      total: data.hits.total
+      hits : data.hits.hits,
+      total : data.hits.total
     };
   }
 };


### PR DESCRIPTION
kinda solves #478
dirty fix that passes the sort and _score fields via a collection transform.
