### PR TITLE
Fix wrong parameter name in README

### DIFF
--- a/packages/easysearch:autosuggest/README.md
+++ b/packages/easysearch:autosuggest/README.md
@@ -17,7 +17,7 @@ You can pass in following parameters to the `EasySearch.Autosuggest` component.
 * __valueField__: String that specifies the document field that contains the autosuggest value, by default "_id"
 * __labelField__: String that specifies the search result field to display, by default the first of index `fields`
 * __changeConfiguration__: Function to change the configuration that is passed to selectize.
-* __suggestionTemplate__: String that specifies a custom template to render the autosuggest, by default `EasySarch.Autogguest.DefaultRenderSuggestion`
+* __renderSuggestion__: String that specifies a custom template to render the autosuggest, by default `EasySarch.Autogguest.DefaultRenderSuggestion`
 
 ## How to install
 


### PR DESCRIPTION
All in the title. One of the parameters was wrong, I had to dig in the source code to find the proper variable name.