### PR TITLE
Call body with options parameter.

### DIFF
--- a/packages/easysearch:elasticsearch/lib/engine.js
+++ b/packages/easysearch:elasticsearch/lib/engine.js
@@ -155,7 +155,7 @@ if (Meteor.isServer) {
     body.sort = this.callConfigMethod('sort', searchDefinition, options);
     body.fields = ['_id'];
 
-    body = this.callConfigMethod('body', body);
+    body = this.callConfigMethod('body', body, options);
 
     options.index.elasticSearchClient.search({
       index: 'easysearch',


### PR DESCRIPTION
There was no way to get the options in the body function. It could be useful to access these options here as well, if generating aggregations etc. issue #588 