### PR TITLE
WIP: ES aggregations.

### DIFF
--- a/packages/easysearch:core/lib/core/index.js
+++ b/packages/easysearch:core/lib/core/index.js
@@ -44,6 +44,7 @@ class Index {
       permission: () => true,
       defaultSearchOptions: {},
       countUpdateIntervalMs: 2000,
+      aggsUpdateIntervalMs: 10000
     };
   }
 

--- a/packages/easysearch:core/lib/core/search-collection.js
+++ b/packages/easysearch:core/lib/core/search-collection.js
@@ -184,7 +184,6 @@ class SearchCollection {
       this.added(collectionName, 'searchCount' + definitionString, { count });
 
       let intervalID;
-
       if (collectionScope._indexConfiguration.countUpdateIntervalMs) {
         intervalID = Meteor.setInterval(
           () => this.changed(
@@ -196,8 +195,28 @@ class SearchCollection {
         );
       }
 
+      const aggs = cursor._aggs;
+
+      if (aggs) {
+        this.added(collectionName, 'aggs' + definitionString, { aggs });
+      }
+
+      let intervalAggsID;
+
+      if (aggs && collectionScope._indexConfiguration.aggsUpdateIntervalMs) {
+        intervalID = Meteor.setInterval(
+          () => this.changed(
+            collectionName,
+            'aggs' + definitionString,
+            { aggs }
+          ),
+          collectionScope._indexConfiguration.aggsUpdateIntervalMs
+        );
+      }
+
       this.onStop(function () {
         intervalID && Meteor.clearInterval(intervalID);
+        intervalAggsID && Meteor.clearInterval(intervalAggsID);
         resultsHandle && resultsHandle.stop();
       });
 

--- a/packages/easysearch:core/lib/main.js
+++ b/packages/easysearch:core/lib/main.js
@@ -1,6 +1,7 @@
 import Index from './core/index';
 import Engine from './core/engine';
 import ReactiveEngine from './core/reactive-engine';
+import SearchCollection from './core/search-collection';
 import Cursor from './core/cursor';
 import MongoDBEngine from './engines/mongo-db';
 import MinimongoEngine from './engines/minimongo';
@@ -13,5 +14,6 @@ export {
   Cursor,
   MongoDBEngine,
   MinimongoEngine,
-  MongoTextIndexEngine
+  MongoTextIndexEngine,
+  SearchCollection
 };

--- a/packages/easysearch:elasticsearch/lib/engine.js
+++ b/packages/easysearch:elasticsearch/lib/engine.js
@@ -1,4 +1,6 @@
 import ElasticSearchDataSyncer from './data-syncer'
+import ESCursor from './cursor'
+import ESSearchCollection from './search-collection'
 
 if (Meteor.isServer) {
   var Future = Npm.require('fibers/future'),
@@ -125,7 +127,12 @@ if (Meteor.isServer) {
    * @param {Object} indexConfig Index configuration
    */
   onIndexCreate(indexConfig) {
-    super.onIndexCreate(indexConfig);
+    if (!indexConfig.allowedFields) {
+      indexConfig.allowedFields = indexConfig.fields;
+    }
+
+    indexConfig.searchCollection = new ESSearchCollection(indexConfig, this);
+    indexConfig.mongoCollection = indexConfig.searchCollection._hitsCollection;
 
     if (Meteor.isServer) {
       indexConfig.elasticSearchClient = new elasticsearch.Client(this.config.client);
@@ -170,7 +177,7 @@ if (Meteor.isServer) {
         return;
       }
 
-      let { total, ids } = this.getCursorData(data),
+      let { total, ids, aggs } = this.getCursorData(data),
         cursor;
 
       if (ids.length > 0) {
@@ -180,10 +187,10 @@ if (Meteor.isServer) {
           })
         }, { limit: options.search.limit });
       } else {
-        cursor = EasySearch.Cursor.emptyCursor;
+        cursor = EasySearch.ESCursor.emptyCursor;
       }
 
-      fut['return'](new EasySearch.Cursor(cursor, total));
+      fut['return'](new ESCursor(cursor, total, true, null, aggs));
     }));
 
     return fut.wait();
@@ -198,8 +205,9 @@ if (Meteor.isServer) {
    */
   getCursorData(data) {
     return {
-      ids : _.map(data.hits.hits, (resultSet) => resultSet._id),
-      total: data.hits.total
+      ids: _.map(data.hits.hits, (resultSet) => resultSet._id),
+      total: data.hits.total,
+      aggs: data.aggregations || {}
     };
   }
 }

--- a/packages/easysearch:elasticsearch/lib/search-collection.js
+++ b/packages/easysearch:elasticsearch/lib/search-collection.js
@@ -1,0 +1,66 @@
+import { SearchCollection } from 'meteor/easysearch:core';
+import ESCursor from './cursor';
+
+/**
+ * A search collection represents a reactive collection on the client,
+ * which is used by the ReactiveEngine for searching using Elasticsearch.
+ *
+ * @type {ESSearchCollection}
+ */
+class ESSearchCollection extends SearchCollection {
+  /**
+   * Constructor
+   *
+   * @param {Object}         indexConfiguration Index configuration
+   * @param {ReactiveEngine} engine             Reactive Engine
+   *
+   * @constructor
+   */
+  constructor() {
+    super(...arguments);
+  }
+
+  /**
+   * Find documents on the client.
+   *
+   * @param {Object} searchDefinition Search definition
+   * @param {Object} options          Options
+   *
+   * @returns {ESCursor}
+   */
+  find(searchDefinition, options) {
+    if (!Meteor.isClient) {
+      throw new Error('find can only be used on client');
+    }
+
+    let publishHandle = Meteor.subscribe(this.name, searchDefinition, options);
+
+    let count = this._getCount(searchDefinition);
+    let aggs = this._getAggregation(searchDefinition);
+    let mongoCursor = this._getMongoCursor(searchDefinition, options);
+
+    if (!_.isNumber(count)) {
+      return new ESCursor(mongoCursor, 0, false, aggs);
+    }
+
+    return new ESCursor(mongoCursor, count, true, publishHandle, aggs);
+  }
+
+  /**
+   * Get the aggregations linked to the search
+   *
+   * @params {Object} searchDefinition Search definition
+   *
+   * @private
+   */
+  _getAggregation(searchDefinition) {
+    const aggsDoc = this._collection.findOne('aggs' + JSON.stringify(searchDefinition));
+    if (aggsDoc) {
+      return aggsDoc.aggs;
+    }
+    return {};
+  }
+
+}
+
+export default ESSearchCollection;

--- a/packages/easysearch:elasticsearch/package.js
+++ b/packages/easysearch:elasticsearch/package.js
@@ -20,6 +20,8 @@ Package.onUse(function(api) {
   api.addFiles([
     'lib/data-syncer.js',
     'lib/engine.js',
+    'lib/cursor.js',
+    'lib/search-collection.js'
   ]);
 
   api.export('EasySearch');


### PR DESCRIPTION
Implementing Elasticsearch aggregations, which are published together with the hits data.

In current implementation, the aggregations are injected in the `body` function like so:
``` javascript
var index = new EasySearch.Index({
  ...
  engine: new EasySearch.ElasticSearch({
    'body': function(body, opts) {
      body.aggs = {
        tags:{
          filter: {},
          aggs: {
            tags: {
              terms: { field: 'tags.not_analyzed' }
            }
          }
        }
      };
      return body;
    }
    ...
  }
});
```

and gets accessible on the cursor returned by the `search` method like this:

```javascript
var cursor = index.search('test');

// get all aggregations
cursor.getAggregations();

// get aggregation by name
cursor.getAggregation('tags');

```