### PR TITLE
Substitutes the default ES query.

### DIFF
--- a/packages/easysearch:elasticsearch/lib/engine.js
+++ b/packages/easysearch:elasticsearch/lib/engine.js
@@ -61,9 +61,12 @@ if (Meteor.isServer) {
 
         _.each(searchObject, function (searchString, field) {
           query.bool.should.push({
-            "fuzzy_like_this": {
-              "fields": [field],
-              "like_text": searchString
+            match: {
+              [field]: {
+                query: searchString,
+                fuzziness: 'AUTO',
+                operator:  'or'
+              }
             }
           });
         });


### PR DESCRIPTION
Uses the match query with `fuzziness: 'AUTO'` and `operator: 'or'`. Fixes #587