### PR TITLE
Update ES client

### DIFF
--- a/packages/easysearch:elasticsearch/package.js
+++ b/packages/easysearch:elasticsearch/package.js
@@ -7,7 +7,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'elasticsearch': '8.2.0'
+  'elasticsearch': '13.0.0'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Updates the elasticsearch client to support ES 5.x. Seems to work with elasticsearch 1.7 as well.