### PR TITLE
Remove _id before indexing. fixes #571

### DIFF
--- a/packages/easysearch:elasticsearch/lib/data-syncer.js
+++ b/packages/easysearch:elasticsearch/lib/data-syncer.js
@@ -19,12 +19,17 @@ class ElasticSearchDataSyncer {
     this.collection = collection;
     this.client = client;
 
+    const removeId = (obj) => {
+      let { _id, ...rest } = obj
+      return rest;
+    }
+
     this.collection.find().observeChanges({
       added: (id, fields) => {
-        this.writeToIndex(beforeIndex(fields), id);
+        this.writeToIndex(removeId(beforeIndex(fields)), id);
       },
       changed: (id) => {
-        this.writeToIndex(beforeIndex(collection.findOne(id)), id);
+        this.writeToIndex(removeId(beforeIndex(collection.findOne(id))), id);
       },
       removed: (id) => {
         this.client.delete({


### PR DESCRIPTION
Issue with Elasticsearch 5.x, which will not accept documents that contain an `_id` variable. This PR implements removal of `_id`before indexing, and make use of the ES client to set the id instead. Seems to still work on older versions of ES (tested on ES 1.7).