### PR TITLE
Added functionality for: reactivity selection, matchAll words, weights and user of Enter to start search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,38 @@
-Easy Search [![Build Status](https://travis-ci.org/matteodem/meteor-easy-search.svg?branch=master)](https://travis-ci.org/matteodem/meteor-easy-search)
+Easy Search 
 =====================
 
 Easy Search is a simple and flexible solution for adding search functionality to your Meteor App. Use the Blaze Components + Javascript API to [get started](http://matteodem.github.io/meteor-easy-search/getting-started).
 
+In this fork we have added some options to the mongo-db engine in order to deal with big queries.
+
 ```javascript
-import { Index, MinimongoEngine } from 'meteor/easy:search'
+import { Index, MongoDBEngine } from 'meteor/easy:search'
 
 // On Client and Server
 const Players = new Mongo.Collection('players')
 const PlayersIndex = new Index({
   collection: Players,
   fields: ['name'],
-  engine: new MinimongoEngine(),
+  engine: new MongoDBEngine({
+    /* sort, and selector as default */
+    /* the following paramters are documented in the meteor docs */
+    disableOplog: true,
+    pollingIntervalMs: 10000,
+    pollingThrottleMs: 1000,
+    maxTimeMs: 30000,
+  }),
+  // added: make the index reactive
+  reactive: false,
+  // make the count updated, only applicable if reactive:true
+  countUpdateIntervalMs: 0,
 })
 ```
+
+The parameters of the `engine` are documented
+[here](https://docs.meteor.com/api/collections.html#Mongo-Collection-find).
+
+The parameters on the index `reactive` is used to indicate reactivity of the queries. If false, the observer handler stops after first completion
+
 
 ```javascript
 // On Client

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Template.searchBox.helpers({
 
 ```html
 <template name="searchBox">
-    {{> EasySearch.Input index=playersIndex }}
+    {{> EasySearch.Input index=playersIndex matchAll=1 enterRequired=0}}
 
     <ul>
         {{#EasySearch.Each index=playersIndex }}
@@ -33,6 +33,15 @@ Template.searchBox.helpers({
     </ul>
 </template>
 ```
+
+This fork has added matchAll and reactive options which are not documented on
+the original documentation.
+
+* `matchAll=1`: the search string will be converted to words with quotes. In Mongo
+this implies that ALL the words are required. For example "this is my search"
+will be converted to ""this" "is" "my" "search"".
+
+* `enterRequired=0`: enable or disable the search while writing
 
 Check out the [searchable leaderboard example](https://github.com/matteodem/easy-search-leaderboard) or have a look at the [current documentation](http://matteodem.github.io/meteor-easy-search/) ([v1 docs](https://github.com/matteodem/meteor-easy-search/tree/gh-pages/_v1docs)) for more information.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,29 @@ The parameters of the `engine` are documented
 
 The parameters on the index `reactive` is used to indicate reactivity of the queries. If false, the observer handler stops after first completion
 
+Now, when using `MongoTextEngine` we can sort by `textScore`, and specify the
+weights for the fields:
+
+```javascript
+import { Index, MongoDBEngine } from 'meteor/easy:search'
+
+// On Client and Server
+const Players = new Mongo.Collection('players')
+const PlayersIndex = new Index({
+  collection: Players,
+  fields: ['name'],
+  engine: new MongoTextIndex({
+    sort: function () {
+      return {"score": { "$meta": "textScore" }, "pub_date": -1};
+    },
+  }),
+  weights: function () {
+      return {"title": 10, "categories": 10, "keywords": 10, "raw_text": 5};
+  },
+)};
+```
+By default, if using `MongoTextIndex` the sort and projection is set to: `{"score": { "$meta": "textScore" }}`
+
 
 ```javascript
 // On Client

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Template.searchBox.helpers({
 
 ```html
 <template name="searchBox">
-    {{> EasySearch.Input index=playersIndex matchAll=1 enterRequired=0}}
+    {{> EasySearch.Input index=playersIndex matchAll=1 autoSearch=0}}
 
     <ul>
         {{#EasySearch.Each index=playersIndex }}
@@ -83,7 +83,7 @@ the original documentation.
 this implies that ALL the words are required. For example "this is my search"
 will be converted to ""this" "is" "my" "search"".
 
-* `enterRequired=0`: enable or disable the search while writing
+* `autoSearch=0`: enable or disable the search while writing
 
 Check out the [searchable leaderboard example](https://github.com/matteodem/easy-search-leaderboard) or have a look at the [current documentation](http://matteodem.github.io/meteor-easy-search/) ([v1 docs](https://github.com/matteodem/meteor-easy-search/tree/gh-pages/_v1docs)) for more information.
 

--- a/packages/easysearch:components/lib/input/input.js
+++ b/packages/easysearch:components/lib/input/input.js
@@ -40,7 +40,7 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
         if ('enter' == this.getData().event && e.keyCode != 13) {
           return;
         }
-        if (this.options.reactive || e.keyCode == 13){
+        if (this.options.autoSearch || e.keyCode == 13){
             var value = $(e.target).val();
 
             if (value.length >= this.options.charLimit) {
@@ -83,7 +83,7 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
    */
   get defaultOptions() {
     return {
-      reactive: 0,
+      autoSearch: 0,
       matchAll: 1,
       timeout: 50,
       charLimit: 0

--- a/packages/easysearch:components/lib/input/input.js
+++ b/packages/easysearch:components/lib/input/input.js
@@ -40,11 +40,16 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
         if ('enter' == this.getData().event && e.keyCode != 13) {
           return;
         }
+        if (this.options.reactive || e.keyCode == 13){
+            var value = $(e.target).val();
 
-        const value = $(e.target).val();
+            if (value.length >= this.options.charLimit) {
+                if (this.options.matchAll && value.trim()) {
+                    value = _.reduce(s.words(value), function(last, w){ return last + ' ' + s.quote(w)}, '');
+                }
 
-        if (value.length >= this.options.charLimit) {
-          this.debouncedSearch($(e.target).val());
+              this.debouncedSearch(value);
+            }
         }
       }
     }];
@@ -78,6 +83,8 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
    */
   get defaultOptions() {
     return {
+      reactive: 0,
+      matchAll: 1,
       timeout: 50,
       charLimit: 0
     };

--- a/packages/easysearch:components/lib/input/input.js
+++ b/packages/easysearch:components/lib/input/input.js
@@ -11,7 +11,14 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
     super.onCreated(...arguments);
 
     this.search(this.inputAttributes().value);
-
+    //pre-process text
+    this.preprocess = (searchString) => {
+        if (this.options.matchAll && searchString.trim()) {
+            searchString = _.reduce(s.words(searchString),
+                    function(last, w){ return last + ' ' + s.quote(w)}, '');
+        }
+        return searchString.trim();
+    },
     // create a reactive dependency to the cursor
     this.debouncedSearch = _.debounce((searchString) => {
       searchString = searchString.trim();
@@ -44,11 +51,8 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
             var value = $(e.target).val();
 
             if (value.length >= this.options.charLimit) {
-                if (this.options.matchAll && value.trim()) {
-                    value = _.reduce(s.words(value), function(last, w){ return last + ' ' + s.quote(w)}, '');
-                }
-
-              this.debouncedSearch(value);
+                value = this.preprocess(value);
+                this.debouncedSearch(value);
             }
         }
       }

--- a/packages/easysearch:components/lib/input/input.js
+++ b/packages/easysearch:components/lib/input/input.js
@@ -87,7 +87,7 @@ EasySearch.InputComponent = class InputComponent extends BaseComponent {
    */
   get defaultOptions() {
     return {
-      autoSearch: 0,
+      autoSearch: 1,
       matchAll: 1,
       timeout: 50,
       charLimit: 0

--- a/packages/easysearch:core/lib/engines/mongo-text-index.js
+++ b/packages/easysearch:core/lib/engines/mongo-text-index.js
@@ -42,16 +42,17 @@ class MongoTextIndexEngine extends ReactiveEngine {
 
     if (Meteor.isServer) {
       let textIndexesConfig = {};
+      let textIndexesWeights = {};
 
       _.each(indexConfig.fields, function (field) {
         textIndexesConfig[field] = 'text';
       });
 
       if (indexConfig.weights) {
-        textIndexesConfig.weights = options.weights();
+        textIndexesWeights.weights = indexConfig.weights();
       }
 
-      indexConfig.collection._ensureIndex(textIndexesConfig);
+      indexConfig.collection._ensureIndex(textIndexesConfig, textIndexesWeights);
     }
   }
 

--- a/packages/easysearch:core/lib/engines/mongo-text-index.js
+++ b/packages/easysearch:core/lib/engines/mongo-text-index.js
@@ -22,6 +22,12 @@ class MongoTextIndexEngine extends ReactiveEngine {
 
       return {};
     };
+    mongoConfiguration.sort = function () {
+      return {"score": { "$meta": "textScore" }};
+    };
+    mongoConfiguration.fields = function () {
+      return {"score": { "$meta": "textScore" }};
+    };
 
     return _.defaults({}, mongoConfiguration, super.defaultConfiguration());
   }


### PR DESCRIPTION
I have added some functionality to the easy:search and easysearch:components:

- Select if the query is reactive: for big queries this is important
- Use enter to start the search instead of while writting (autoSearch={0, 1})
- Indicate to the input field if the match of words uses AND or OR operator (matchAll={0, 1})
- Weights added for the MongoTextIndex (I didn't get to work with the default version)