### PR TITLE
Fix issue around document count changing

### DIFF
--- a/packages/easysearch:core/lib/core/search-collection.js
+++ b/packages/easysearch:core/lib/core/search-collection.js
@@ -192,7 +192,7 @@ class SearchCollection {
           () => this.changed(
             collectionName,
             'searchCount' + definitionString,
-            { count: cursor.mongoCursor.count && cursor.mongoCursor.count() || 0 }
+            { count: cursor.count && cursor.count() || 0 }
           ),
           collectionScope._indexConfiguration.countUpdateIntervalMs
         );


### PR DESCRIPTION
Changing cursor.mongoCursor.count() to cursor.count() to prevent the publication returning the wrong count. This stops the pagination component from disappearing.